### PR TITLE
테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jia/study_tracker/service/StudyMessageFilter.java
+++ b/src/main/java/com/jia/study_tracker/service/StudyMessageFilter.java
@@ -1,0 +1,18 @@
+package com.jia.study_tracker.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Component
+public class StudyMessageFilter {
+
+    private static final List<String> STUDY_KEYWORDS = List.of("공부", "강의", "복습", "학습", "인강", "문제풀이");
+
+    public boolean isStudyRelated(String text) {
+        if (!StringUtils.hasText(text)) return false;
+        return STUDY_KEYWORDS.stream().anyMatch(text::contains);
+    }
+
+}

--- a/src/main/java/com/jia/study_tracker/slack/SlackEventPayload.java
+++ b/src/main/java/com/jia/study_tracker/slack/SlackEventPayload.java
@@ -1,17 +1,18 @@
 package com.jia.study_tracker.slack;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class SlackEventPayload {
     private String type;
     private String challenge;
     private Event event;
 
     @Getter
-    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Event {
         private String type;
         private String user;

--- a/src/main/java/com/jia/study_tracker/slack/SlackEventService.java
+++ b/src/main/java/com/jia/study_tracker/slack/SlackEventService.java
@@ -3,6 +3,7 @@ package com.jia.study_tracker.slack;
 
 import com.jia.study_tracker.domain.StudyLog;
 import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.service.StudyMessageFilter;
 import com.jia.study_tracker.service.UserService;
 import com.jia.study_tracker.repository.StudyLogRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class SlackEventService {
 
     private final UserService userService;
     private final StudyLogRepository studyLogRepository;
-
+    private final StudyMessageFilter studyMessageFilter;
 
     public String handleEvent(SlackEventPayload payload) {
         // 1. URL 인증
@@ -33,6 +34,11 @@ public class SlackEventService {
             if ("message".equals(event.getType())) {
                 String slackUserId = event.getUser();
                 String text = event.getText();
+
+                if (!studyMessageFilter.isStudyRelated(text)) {
+                    log.info("🚫 저장되지 않은 메시지: {}", text);
+                    return "학습과 관련 없는 메시지는 저장되지 않습니다.";
+                }
 
                 User user = userService.findOrCreateUser(slackUserId, "unknown");
                 StudyLog studyLog = new StudyLog(text, LocalDateTime.now(), user);

--- a/src/main/java/com/jia/study_tracker/slack/SlackRequestVerifier.java
+++ b/src/main/java/com/jia/study_tracker/slack/SlackRequestVerifier.java
@@ -72,4 +72,9 @@ public class SlackRequestVerifier {
             throw new HmacCalculationException("HMAC-SHA256 계산 중 오류 발생", e);
         }
     }
+
+    // 테스트할 때 signingSecret 직접 주입할 수 있게 만든 메소드
+    public void setSigningSecret(String signingSecret) {
+        this.signingSecret = signingSecret;
+    }
 }

--- a/src/test/java/com/jia/study_tracker/SlackIntegrationTest.java
+++ b/src/test/java/com/jia/study_tracker/SlackIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.jia.study_tracker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jia.study_tracker.repository.StudyLogRepository;
+import com.jia.study_tracker.repository.UserRepository;
+import com.jia.study_tracker.slack.SlackEventPayload;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slack 요청, DB 저장 기능에 대한 통합 테스트
+ */
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class SlackIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyLogRepository studyLogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${slack.signing-secret}")
+    private String signingSecret;
+
+    @Test
+    void slackMessageEvent_createsUserAndStudyLog() throws Exception {
+        // Given
+        String slackUserId = "user123";
+        String message = "Studied Spring Boot today!";
+        SlackEventPayload.Event event = new SlackEventPayload.Event("message", slackUserId, message);
+        SlackEventPayload payload = new SlackEventPayload("event_callback", null, event);
+
+        String requestBody = objectMapper.writeValueAsString(payload);
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        String signature = generateSlackSignature(timestamp, requestBody);
+
+        // When
+        mockMvc.perform(post("/slack/events")
+                        .header("X-Slack-Signature", signature)
+                        .header("X-Slack-Request-Timestamp", timestamp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+
+        // Then
+        assertTrue(userRepository.findById(slackUserId).isPresent());
+        assertFalse(studyLogRepository.findAll().isEmpty());
+    }
+
+    // 테스트용 HMAC-SHA256 서명 생성 메서드
+    private String generateSlackSignature(String timestamp, String body) throws Exception {
+        String baseString = "v0:" + timestamp + ":" + body;
+        SecretKeySpec key = new SecretKeySpec(signingSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(key);
+        byte[] hmac = mac.doFinal(baseString.getBytes(StandardCharsets.UTF_8));
+        return "v0=" + HexFormat.of().formatHex(hmac);
+    }
+
+}

--- a/src/test/java/com/jia/study_tracker/SlackIntegrationTest.java
+++ b/src/test/java/com/jia/study_tracker/SlackIntegrationTest.java
@@ -52,7 +52,7 @@ public class SlackIntegrationTest {
     void slackMessageEvent_createsUserAndStudyLog() throws Exception {
         // Given
         String slackUserId = "user123";
-        String message = "Studied Spring Boot today!";
+        String message = "스프링을 공부했다";
         SlackEventPayload.Event event = new SlackEventPayload.Event("message", slackUserId, message);
         SlackEventPayload payload = new SlackEventPayload("event_callback", null, event);
 

--- a/src/test/java/com/jia/study_tracker/service/StudyMessageFilterTest.java
+++ b/src/test/java/com/jia/study_tracker/service/StudyMessageFilterTest.java
@@ -1,0 +1,30 @@
+package com.jia.study_tracker.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class StudyMessageFilterTest {
+
+    private final StudyMessageFilter filter = new StudyMessageFilter();
+
+    @Test
+    void returnsTrueWhenTextContainsStudyKeywords() {
+        assertTrue(filter.isStudyRelated("오늘 인강 2시간 들음"));
+        assertTrue(filter.isStudyRelated("문제풀이를 했어요"));
+        assertTrue(filter.isStudyRelated("강의 복습 중이에요"));
+    }
+
+    @Test
+    void returnsFalseWhenTextDoesNotContainStudyKeywords() {
+        assertFalse(filter.isStudyRelated("오늘 영화 봤어요"));
+        assertFalse(filter.isStudyRelated("점심은 뭐 먹지"));
+        assertFalse(filter.isStudyRelated("고양이가 귀엽다"));
+    }
+
+    @Test
+    void returnsFalseWhenTextIsEmptyOrNull() {
+        assertFalse(filter.isStudyRelated(""));
+        assertFalse(filter.isStudyRelated(null));
+    }
+}

--- a/src/test/java/com/jia/study_tracker/service/UserServiceTest.java
+++ b/src/test/java/com/jia/study_tracker/service/UserServiceTest.java
@@ -1,0 +1,79 @@
+package com.jia.study_tracker.service;
+
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * UserService 테스트
+ *
+ * 목표:
+ * - findOrCreateUser 메서드가 정상 동작하는지 검증한다.
+ *
+ * 테스트 시나리오:
+ * 1. 사용자가 DB에 존재하는 경우, 해당 사용자를 반환해야 한다.
+ * 2. 사용자가 DB에 존재하지 않는 경우, 새로운 사용자를 생성하여 반환해야 한다.
+ *
+ * 주의사항:
+ * - 동시성 테스트는 별도의 추가 테스트 케이스로 다룰 수 있으며,
+ *   여기서는 기본 동작만 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    // 기존 유저가 존재하는 경우, 해당 유저를 반환하는지 테스트
+    @Test
+    void findOrCreateUser_existingUser_returnsUser() {
+        // Given
+        String slackUserId = "user123";
+        String slackUsername = "testUser";
+        User existingUser = new User(slackUserId, slackUsername);
+        Mockito.when(userRepository.findById(slackUserId)).thenReturn(Optional.of(existingUser));
+
+        // When
+        User user = userService.findOrCreateUser(slackUserId, slackUsername);
+
+        // Then
+        assertEquals(slackUserId, user.getSlackUserId());
+        assertEquals(slackUsername, user.getSlackUsername());
+    }
+
+    // 새로운 유저가 없는 경우, 새로 생성하고 반환하는지 테스트
+    @Test
+    void findOrCreateUser_newUser_createsAndReturnsUser() {
+        // Given
+        String slackUserId = "user123";
+        String slackUsername = "newUser";
+        Mockito.when(userRepository.findById(slackUserId)).thenReturn(Optional.empty());
+
+        // save 메서드를 목(mock)으로 처리
+        User newUser = new User(slackUserId, slackUsername);
+        Mockito.when(userRepository.save(Mockito.any(User.class))).thenReturn(newUser);
+
+        // When
+        User user = userService.findOrCreateUser(slackUserId, slackUsername);
+
+        // Then
+        assertNotNull(user);
+        assertEquals(slackUserId, user.getSlackUserId());
+        assertEquals(slackUsername, user.getSlackUsername());
+    }
+
+}

--- a/src/test/java/com/jia/study_tracker/slack/SlackEventControllerTest.java
+++ b/src/test/java/com/jia/study_tracker/slack/SlackEventControllerTest.java
@@ -1,0 +1,72 @@
+package com.jia.study_tracker.slack;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SlackEventController 테스트
+ *
+ * 목표: HTTP 요청이 잘 처리되는지 확인한다.
+ *
+ * 테스트 시나리오:
+ * 1. 유효한 슬랙 요청이 들어오면 200 OK 응답을 반환한다.
+ * 2. 유효하지 않은 슬랙 요청이 들어오면 401 Unauthorized 응답을 반환한다.
+ */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(SlackEventController.class)
+public class SlackEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SlackEventService slackEventService;
+
+    @MockBean
+    private SlackRequestVerifier slackRequestVerifier;
+
+    // 유효한 슬랙 요청이 들어오면 200 OK 응답을 반환하는지 테스트
+    @Test
+    void receiveEvent_validRequest_returnsOk() throws Exception {
+        // Given
+        String signature = "validSignature";
+        String timestamp = "validTimestamp";
+        String body = "{}";
+
+        Mockito.when(slackRequestVerifier.isValid(signature, timestamp, body)).thenReturn(true);
+
+        // When & Then
+        mockMvc.perform(post("/slack/events")
+                        .header("X-Slack-Signature", signature)
+                        .header("X-Slack-Request-Timestamp", timestamp)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    // 유효하지 않은 슬랙 요청이 들어오면 401 Unauthorized 응답을 반환하는지 테스트
+    @Test
+    void receiveEvent_invalidRequest_returnsUnauthorized() throws Exception {
+        // Given
+        String signature = "invalidSignature";
+        String timestamp = "invalidTimestamp";
+        String body = "{}";
+
+        Mockito.when(slackRequestVerifier.isValid(signature, timestamp, body)).thenReturn(false);
+
+        // When & Then
+        mockMvc.perform(post("/slack/events")
+                        .header("X-Slack-Signature", signature)
+                        .header("X-Slack-Request-Timestamp", timestamp)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/jia/study_tracker/slack/SlackEventServiceTest.java
+++ b/src/test/java/com/jia/study_tracker/slack/SlackEventServiceTest.java
@@ -1,0 +1,71 @@
+package com.jia.study_tracker.slack;
+
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.repository.StudyLogRepository;
+import com.jia.study_tracker.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SlackEventService 테스트
+ *
+ * 목표:
+ * - 슬랙 이벤트가 잘 처리되는지 검증한다.
+ *
+ * 테스트 시나리오:
+ * 1. 슬랙에서 메시지가 오면 StudyLog에 저장되어야 한다.
+ * 2. 슬랙에서 url_verification 이벤트가 오면 challenge를 반환해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SlackEventServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private StudyLogRepository studyLogRepository;
+
+    @InjectMocks
+    private SlackEventService slackEventService;
+
+    // 슬랙 메시지 이벤트를 처리해서 StudyLog에 저장하는지 검증
+    @Test
+    void handleEvent_messageEvent_savesStudyLog() {
+        // Given
+        String slackUserId = "user123";
+        String message = "Studied Spring Boot today!";
+        SlackEventPayload.Event event = new SlackEventPayload.Event("message", slackUserId, message);
+        SlackEventPayload payload = new SlackEventPayload("event_callback", null, event);
+
+        User user = new User(slackUserId, "testUser");
+        Mockito.when(userService.findOrCreateUser(slackUserId, "unknown")).thenReturn(user);
+
+        // When
+        String response = slackEventService.handleEvent(payload);
+
+        // Then
+        Mockito.verify(studyLogRepository).save(Mockito.any(StudyLog.class));
+        assertEquals("ok", response);
+    }
+
+    // 슬랙 url_verification 이벤트가 오면 challenge 값을 반환하는지 검증
+    @Test
+    void handleEvent_urlVerification_returnsChallenge() {
+        // Given
+        SlackEventPayload payload = new SlackEventPayload("url_verification", "testChallenge", null);
+
+        // When
+        String response = slackEventService.handleEvent(payload);
+
+        // Then
+        assertEquals("testChallenge", response);
+    }
+
+}

--- a/src/test/java/com/jia/study_tracker/slack/SlackEventServiceTest.java
+++ b/src/test/java/com/jia/study_tracker/slack/SlackEventServiceTest.java
@@ -3,6 +3,7 @@ package com.jia.study_tracker.slack;
 import com.jia.study_tracker.domain.StudyLog;
 import com.jia.study_tracker.domain.User;
 import com.jia.study_tracker.repository.StudyLogRepository;
+import com.jia.study_tracker.service.StudyMessageFilter;
 import com.jia.study_tracker.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ public class SlackEventServiceTest {
     @Mock
     private StudyLogRepository studyLogRepository;
 
+    @Mock
+    private StudyMessageFilter studyMessageFilter;
+
     @InjectMocks
     private SlackEventService slackEventService;
 
@@ -40,12 +44,13 @@ public class SlackEventServiceTest {
     void handleEvent_messageEvent_savesStudyLog() {
         // Given
         String slackUserId = "user123";
-        String message = "Studied Spring Boot today!";
+        String message = "스프링을 공부했다";
         SlackEventPayload.Event event = new SlackEventPayload.Event("message", slackUserId, message);
         SlackEventPayload payload = new SlackEventPayload("event_callback", null, event);
 
         User user = new User(slackUserId, "testUser");
         Mockito.when(userService.findOrCreateUser(slackUserId, "unknown")).thenReturn(user);
+        Mockito.when(studyMessageFilter.isStudyRelated(Mockito.anyString())).thenReturn(true);
 
         // When
         String response = slackEventService.handleEvent(payload);

--- a/src/test/java/com/jia/study_tracker/slack/SlackRequestVerifierTest.java
+++ b/src/test/java/com/jia/study_tracker/slack/SlackRequestVerifierTest.java
@@ -1,0 +1,100 @@
+package com.jia.study_tracker.slack;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SlackRequestVerifier 테스트
+ *
+ * 목표:
+ * - Slack 서명 검증 기능이 올바르게 동작하는지 확인한다.
+ *
+ * 테스트 시나리오:
+ * - 유효한 서명이 전달되었을 때 검증이 성공해야 한다.
+ * - 오래된 timestamp가 전달되면 실패해야 한다.
+ * - 서명이 잘못된 경우 실패해야 한다.
+ *
+ * 참고:
+ * - 서명 검증은 Signing Secret을 기반으로 HMAC-SHA256 방식으로 이루어진다.
+ * - 이 테스트에서는 Signing Secret을 dummy 값으로 설정하고,
+ *   signature 및 timestamp를 제어해 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SlackRequestVerifierTest {
+
+    private SlackRequestVerifier slackRequestVerifier;
+
+    private static final String DUMMY_SIGNING_SECRET = "dummy_secret";
+
+    @BeforeEach
+    void setUp() {
+        slackRequestVerifier = new SlackRequestVerifier();
+        slackRequestVerifier.setSigningSecret(DUMMY_SIGNING_SECRET);
+    }
+
+    // 유효한 슬랙 요청이 들어오면 true를 반환해야 한다.
+    @Test
+    void isValid_validRequest_returnsTrue() throws Exception {
+        // Given
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000); // 현재 시간
+        String body = "test_body";
+        String baseString = "v0:" + timestamp + ":" + body;
+        String validSignature = "v0=" + calculateHmacSHA256(baseString, DUMMY_SIGNING_SECRET);
+
+        // When
+        boolean isValid = slackRequestVerifier.isValid(validSignature, timestamp, body);
+
+        // Then
+        assertTrue(isValid);
+    }
+
+    // 오래된 timestamp가 전달되면 false를 반환해야 한다.
+    @Test
+    void isValid_invalidTimestamp_returnsFalse() throws Exception {
+        // Given
+        String oldTimestamp = "1234567890";
+        String body = "test_body";
+        String baseString = "v0:" + oldTimestamp + ":" + body;
+        String validSignature = "v0=" + calculateHmacSHA256(baseString, DUMMY_SIGNING_SECRET);
+
+        // When
+        boolean isValid = slackRequestVerifier.isValid(validSignature, oldTimestamp, body);
+
+        // Then
+        assertFalse(isValid);
+    }
+
+    // 잘못된 서명이 전달되면 false를 반환해야 한다.
+    @Test
+    void isValid_invalidSignature_returnsFalse() {
+        // Given
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        String body = "test_body";
+        String invalidSignature = "v0=invalidsignature";
+
+        // When
+        boolean isValid = slackRequestVerifier.isValid(invalidSignature, timestamp, body);
+
+        // Then
+        assertFalse(isValid);
+    }
+
+    // 테스트용 HMAC-SHA256 서명 생성 메서드
+    private String calculateHmacSHA256(String data, String secret) throws Exception {
+        SecretKeySpec key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(key);
+        byte[] hmac = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return HexFormat.of().formatHex(hmac);
+    }
+}


### PR DESCRIPTION
## 첫 커밋에서 한 것 :
각 서비스 클래스의 기본 기능 테스트 작성
Slack 이벤트 처리 흐름 테스트 작성
테스트 코드에서 setter메서드를 쓰고 싶지 않아, SlackEventPayload DTO에 @AllArgsConstructor 추가

## 추후 구현 예정 :
UserService의 동시성 관련 테스트는 추후 추가 예정
예외 처리, 통합 테스트 등 추가 작업 예정