### PR TITLE
일단위의 스케줄러 구현과 open ai api로 호출해서 요약, 피드백 생성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: echo "Environment variables loaded"
 
       - name: Grant execute permission for gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/jia/study_tracker/config/WebClientConfig.java
+++ b/src/main/java/com/jia/study_tracker/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.jia.study_tracker.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * - OpenAI API 호출 등에 사용할 WebClient를 빈으로 등록하는 설정 클래스
+ */
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/com/jia/study_tracker/scheduler/DailySummaryScheduler.java
+++ b/src/main/java/com/jia/study_tracker/scheduler/DailySummaryScheduler.java
@@ -1,0 +1,71 @@
+package com.jia.study_tracker.scheduler;
+
+import com.jia.study_tracker.domain.DailySummary;
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.repository.DailySummaryRepository;
+import com.jia.study_tracker.repository.UserRepository;
+import com.jia.study_tracker.service.OpenAIClient;
+import com.jia.study_tracker.service.StudyLogQueryService;
+import com.jia.study_tracker.service.dto.SummaryResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 매일 정해진 시간(밤 10시)에 모든 사용자들의 학습 로그를 조회하고,
+ * OpenAI를 통해 학습 요약 및 동기부여 피드백을 생성하여 저장하는 스케줄러 컴포넌트
+ *
+ * 주요 책임:
+ * - 전체 사용자 조회
+ * - 각 사용자의 당일 학습 로그 가져오기
+ * - OpenAI API 호출을 통해 요약 및 피드백 생성
+ * - 결과를 DailySummary 엔티티로 저장
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailySummaryScheduler {
+
+    private final UserRepository userRepository; // 전체 사용자 조회 목적
+    private final StudyLogQueryService studyLogQueryService; // 날짜별 학습 로그 조회 목적
+    private final OpenAIClient openAIClient; // OpenAI API를 호출하여 요약 및 피드백을 생성 목적
+    private final DailySummaryRepository dailySummaryRepository; // // 생성된 요약 및 피드백을 저장하기 위한 목적
+
+    @Scheduled(cron = "0 0 22 * * *") // 매일 밤 10시 실행
+    public void generateDailySummaries() {
+        LocalDate today = LocalDate.now();
+        List<User> users = userRepository.findAll();
+
+        for (User user : users) {
+            // 사용자의 오늘 학습 로그 조회
+            List<StudyLog> logs = studyLogQueryService.getDailyLogs(user.getSlackUserId(), today);
+
+            // 로그가 없는 경우 스킵
+            if (logs.isEmpty()) {
+                log.info("❌ [{}] 오늘의 로그 없음 - 요약 생략", user.getSlackUsername());
+                continue;
+            }
+
+            // GPT를 이용한 요약 및 피드백 생성
+            SummaryResult result = openAIClient.generateSummaryAndFeedback(logs);
+
+            // 결과를 엔티티로 변환하여 저장
+            DailySummary summary = new DailySummary(
+                    today,
+                    result.getSummary(),
+                    result.getFeedback(),
+                    true,
+                    null,
+                    user
+            );
+            dailySummaryRepository.save(summary);
+
+            log.info("✅ [{}] 요약/피드백 저장 완료", user.getSlackUsername());
+        }
+    }
+}

--- a/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
+++ b/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
@@ -1,0 +1,113 @@
+package com.jia.study_tracker.service;
+
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.service.dto.SummaryResult;
+import com.jia.study_tracker.service.dto.openai.Message;
+import com.jia.study_tracker.service.dto.openai.OpenAIRequest;
+import com.jia.study_tracker.service.dto.openai.OpenAIResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 사용자의 학습 로그를 OpenAI API에 전달하여 요약 및 피드백을 생성하는 컴포넌트
+ *
+ * 역할:
+ * - StudyLog 리스트를 문자열로 변환 후 프롬프트 형태로 구성
+ * - OpenAI의 Chat Completion API에 요청을 보내고 응답을 파싱
+ * - 요약 및 피드백을 추출하여 SummaryResult 객체로 반환
+ *
+ * 특징:
+ * - Spring WebClient를 사용한 비동기 HTTP 요청
+ * - 실패 시 기본 메시지 반환 및 예외 로깅 처리
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAIClient {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Value("${openai.model:gpt-3.5-turbo}")
+    private String model;
+
+    // WebClient는 외부 HTTP 요청을 위한 스프링 비동기 클라이언트
+    private final WebClient.Builder webClientBuilder;
+
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+
+    /**
+     * 메소드 : 학습 로그 리스트를 받아 OpenAI에 요청하고 요약 및 피드백을 생성
+     *
+     * @param logs 사용자의 하루 학습 로그 목록
+     * @return 요약 및 피드백이 담긴 SummaryResult
+     */
+    public SummaryResult generateSummaryAndFeedback(List<StudyLog> logs) {
+        // StudyLog의 content만 추출하여 한 개의 문자열로 결합
+        String joinedContent = logs.stream()
+                .map(StudyLog::getContent)
+                .collect(Collectors.joining("\n"));
+
+        // OpenAI에게 전달할 프롬프트 구성
+        String prompt = String.format("""
+                다음은 사용자의 학습 로그입니다:
+                ---
+                %s
+                ---
+
+                위 내용을 3~4문장 이내로 요약해줘. 그리고 학습을 응원하는 동기부여 성격의 짧은 피드백을 함께 작성해줘.
+                출력 형식은 다음과 같이 해줘:
+
+                요약: ~~~
+                피드백: ~~~
+                """, joinedContent);
+
+        // DTO 기반 요청 생성
+        OpenAIRequest request = new OpenAIRequest(
+                model,
+                List.of(
+                        new Message("system", "너는 친절한 학습 요약 봇이야."),
+                        new Message("user", prompt)
+                )
+        );
+
+        try {
+            // DTO 기반 응답 처리
+            OpenAIResponse response = webClientBuilder.build()
+                    .post()
+                    .uri(API_URL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(OpenAIResponse.class)
+                    .block(); // 블로킹 방식으로 대기
+
+            if (response == null || response.choices().isEmpty()) {
+                throw new RuntimeException("OpenAI 응답이 비어있습니다.");
+            }
+
+            // 응답에서 message → content 추출
+            String content = response.choices().get(0).message().content();
+            // content 문자열에서 요약과 피드백 분리
+            String[] parts = content.split("피드백:");
+
+            String summary = parts[0].replace("요약:", "").trim();
+            String feedback = parts.length > 1 ? parts[1].trim() : "피드백 없음";
+
+            return new SummaryResult(summary, feedback);
+
+        } catch (Exception e) {
+            log.error("OpenAI 호출 실패", e);
+            return new SummaryResult("요약 실패", "피드백 생성 실패");
+        }
+    }
+}

--- a/src/main/java/com/jia/study_tracker/service/StudyLogQueryService.java
+++ b/src/main/java/com/jia/study_tracker/service/StudyLogQueryService.java
@@ -12,6 +12,14 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 
+/**
+ * StudyLogQueryService는 사용자 ID(slackUserId)를 기반으로
+ * 일/주/월 단위의 학습 기록을 조회하는 기능을 제공합니다.
+ *
+ * 이 서비스는 읽기 전용 쿼리 기능만 담당하며,
+ * 사용자나 학습 기록을 수정하지 않습니다.
+ */
+
 @Service
 @RequiredArgsConstructor
 public class StudyLogQueryService {

--- a/src/main/java/com/jia/study_tracker/service/dto/SummaryResult.java
+++ b/src/main/java/com/jia/study_tracker/service/dto/SummaryResult.java
@@ -1,0 +1,16 @@
+package com.jia.study_tracker.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * OpenAI로부터 받은 요약 및 피드백 결과를 담는 DTO 클래스
+ *
+ * 역할: OpenAIClient에서 생성한 summary, feedback을 전달
+ */
+@Getter
+@AllArgsConstructor
+public class SummaryResult {
+    private String summary; // 학습 내용 요약
+    private String feedback; // 동기부여 피드백
+}

--- a/src/main/java/com/jia/study_tracker/service/dto/openai/Message.java
+++ b/src/main/java/com/jia/study_tracker/service/dto/openai/Message.java
@@ -1,0 +1,4 @@
+package com.jia.study_tracker.service.dto.openai;
+
+// OpenAI API에 전달할 메시지를 나타내는 DTO (역할: user, system / 내용: content)
+public record Message(String role, String content) {}

--- a/src/main/java/com/jia/study_tracker/service/dto/openai/OpenAIRequest.java
+++ b/src/main/java/com/jia/study_tracker/service/dto/openai/OpenAIRequest.java
@@ -1,0 +1,6 @@
+package com.jia.study_tracker.service.dto.openai;
+
+import java.util.List;
+
+// OpenAI API에 보낼 요청 데이터를 담는 DTO. (모델명 + 메시지 리스트)
+public record OpenAIRequest(String model, List<Message> messages) {}

--- a/src/main/java/com/jia/study_tracker/service/dto/openai/OpenAIResponse.java
+++ b/src/main/java/com/jia/study_tracker/service/dto/openai/OpenAIResponse.java
@@ -1,0 +1,13 @@
+package com.jia.study_tracker.service.dto.openai;
+
+import java.util.List;
+
+/**
+ * OpenAI API의 응답을 담는 DTO.
+ * 응답의 주요 내용은 Choice 객체 내부의 Message에 포함됨.
+ */
+public record OpenAIResponse(List<Choice> choices) {
+
+    // 실제 메시지는 내부 message 필드에 존재.
+    public record Choice(Message message) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ logging:
 slack:
   bot-token: ${SLACK_BOT_TOKEN}
   signing-secret: ${SLACK_SIGNING_SECRET}
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  url: https://api.openai.com/v1/chat/completions
+  model: gpt-3.5-turbo

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,3 +27,9 @@ logging:
 slack:
   bot-token: ${SLACK_BOT_TOKEN:dummy-token}
   signing-secret: ${SLACK_SIGNING_SECRET:dummy-secret}
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  url: https://api.openai.com/v1/chat/completions
+  model: gpt-3.5-turbo
+


### PR DESCRIPTION
# 구현한 기능 :
DailySummaryScheduler가 open ai호출해서 요약/피드백 생성 → DailySummary로 DB에 저장

## 특징 : 
- 현재 일, 주, 월 단위 중 일단위의 요약, 피드백 제공만 했습니다.
- openai api에서 요청, 응답하는 과정에서 dto를 쓰기 위해 Message, OpenAIRequest, OpenAIResponse 클래스를 만들었고 이것들을 record로 구현했습니다.

## 그외 수정한 것
:
- openai api에서 키를 받아서 yml에 넣고 수정
- webclient를 쓰기 위해 의존성 추가.
- StudyLogQueryService 클래스에 이해를 돕기 위한 주석 추가

## 앞으로 할 것들
:
- ai가 만들어준 DailySummary를 슬랙에 전송하는 기능을 만들어야 합니다.
- 주단위, 월단위를 만드는 것도 생각해야합니다.
- 테스트 코드를 작성해야 합니다.


* 커밋 단위가 뚱뚱한 것 같아 죄송합니다..! 좋은 휴일 보내세요 !