### PR TITLE
책임분산, 가독성을 위해 리팩토링 + 주, 월단위 스케줄러 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - name: Checkout source code
@@ -19,13 +23,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Load environment variables
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: echo "Environment variables loaded"
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/src/main/java/com/jia/study_tracker/LogTestRunner.java
+++ b/src/main/java/com/jia/study_tracker/LogTestRunner.java
@@ -1,6 +1,7 @@
 package com.jia.study_tracker;
 
 import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.SummaryType;
 import com.jia.study_tracker.service.StudyLogQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
@@ -17,10 +18,13 @@ public class LogTestRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        List<StudyLog> dailyLogs = studyLogQueryService.getDailyLogs("U123456", LocalDate.of(2025, 5, 2));
+        List<StudyLog> dailyLogs = studyLogQueryService.getLogs("U123456", LocalDate.of(2025, 5, 2), SummaryType.DAILY);
         dailyLogs.forEach(log -> System.out.println("✅ 로그: " + log.getContent()));
 
-        List<StudyLog> weeklyLogs = studyLogQueryService.getWeeklyLogs("U123456", LocalDate.of(2025, 4, 29)); // 주 시작일
+        List<StudyLog> weeklyLogs = studyLogQueryService.getLogs("U123456", LocalDate.of(2025, 4, 29), SummaryType.WEEKLY);
         System.out.println("📅 주간 로그 개수: " + weeklyLogs.size());
+
+        List<StudyLog> monthlyLogs = studyLogQueryService.getLogs("U123456", LocalDate.of(2025, 4, 1), SummaryType.MONTHLY);
+        System.out.println("📆 월간 로그 개수: " + monthlyLogs.size());
     }
 }

--- a/src/main/java/com/jia/study_tracker/scheduler/MonthlySummaryScheduler.java
+++ b/src/main/java/com/jia/study_tracker/scheduler/MonthlySummaryScheduler.java
@@ -10,17 +10,19 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 
 /**
- * 매일 밤 10시 스케줄러 작동
+ * 매월 1일 밤 8시 스케줄러 작동
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class DailySummaryScheduler {
+public class MonthlySummaryScheduler {
 
     private final SummaryGenerationService summaryGenerationService;
 
-    @Scheduled(cron = "0 0 22 * * *")
-    public void generateDailySummaries() {
-        summaryGenerationService.generateSummaries(LocalDate.now(), SummaryType.DAILY);
+    @Scheduled(cron = "0 0 20 1 * *")
+    public void generateMonthlySummaries() {
+        LocalDate today = LocalDate.now();
+        summaryGenerationService.generateSummaries(today, SummaryType.MONTHLY);
     }
 }
+

--- a/src/main/java/com/jia/study_tracker/scheduler/WeeklySummaryScheduler.java
+++ b/src/main/java/com/jia/study_tracker/scheduler/WeeklySummaryScheduler.java
@@ -10,17 +10,19 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 
 /**
- * 매일 밤 10시 스케줄러 작동
+ * 매주 일요일 밤 9시 스케줄러 작동
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class DailySummaryScheduler {
+public class WeeklySummaryScheduler {
 
     private final SummaryGenerationService summaryGenerationService;
 
-    @Scheduled(cron = "0 0 22 * * *")
-    public void generateDailySummaries() {
-        summaryGenerationService.generateSummaries(LocalDate.now(), SummaryType.DAILY);
+    @Scheduled(cron = "0 0 21 * * SUN")
+    public void generateWeeklySummaries() {
+        LocalDate today = LocalDate.now();
+        summaryGenerationService.generateSummaries(today, SummaryType.WEEKLY);
     }
 }
+

--- a/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
+++ b/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
@@ -36,7 +36,7 @@ public class OpenAIClient {
     @Value("${openai.api-key}")
     private String apiKey;
 
-    @Value("${openai.model:gpt-3.5-turbo}")
+    @Value("${openai.model:gpt-4o-mini}")
     private String model;
 
     // WebClient는 외부 HTTP 요청을 위한 스프링 비동기 클라이언트
@@ -63,8 +63,8 @@ public class OpenAIClient {
                 %s
                 ---
 
-                위 내용을 3~4문장 이내로 요약해줘. 그리고 학습을 응원하는 동기부여 성격의 짧은 피드백을 함께 작성해줘.
-                출력 형식은 다음과 같이 해줘:
+                위 내용을 3~4문장 이내로 요약해주세요. 그리고 학습을 응원하는 동기부여 성격의 짧은 피드백을 함께 작성해주세요.
+                출력 형식은 다음과 같이 해주세요:
 
                 요약: ~~~
                 피드백: ~~~
@@ -74,7 +74,7 @@ public class OpenAIClient {
         OpenAIRequest request = new OpenAIRequest(
                 model,
                 List.of(
-                        new Message("system", "너는 친절한 학습 요약 봇이야."),
+                        new Message("system", "나는 친절한 학습 요약 봇이야."),
                         new Message("user", prompt)
                 )
         );

--- a/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
+++ b/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
@@ -1,0 +1,64 @@
+package com.jia.study_tracker.service;
+
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.Summary;
+import com.jia.study_tracker.domain.SummaryType;
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.repository.SummaryRepository;
+import com.jia.study_tracker.repository.UserRepository;
+import com.jia.study_tracker.service.dto.SummaryResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 사용자별 로그를 조회하고, OpenAI를 통해 요약을 생성하여 DB에 저장하는 스케줄러 컴포넌트
+ *
+ * 주요 책임:
+ * - 전체 사용자 조회
+ * - 각 사용자의 당일 학습 로그 가져오기
+ * - OpenAI API 호출을 통해 요약 및 피드백 생성
+ * - 결과를 Summary 엔티티로 저장
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SummaryGenerationService {
+
+    private final UserRepository userRepository;
+    private final StudyLogQueryService studyLogQueryService;
+    private final OpenAIClient openAIClient;
+    private final SummaryRepository summaryRepository;
+
+    public void generateSummaries(LocalDate date, SummaryType type) {
+        List<User> users = userRepository.findAll();
+
+        for (User user : users) {
+            List<StudyLog> logs = studyLogQueryService.getLogs(user.getSlackUserId(), date, type);
+
+            if (logs.isEmpty()) {
+                log.info("❌ [{}] {} 로그 없음 - 요약 생략", user.getSlackUsername(), type);
+                continue;
+            }
+
+            SummaryResult result = openAIClient.generateSummaryAndFeedback(logs);
+
+            Summary summary = new Summary(
+                    date,
+                    result.getSummary(),
+                    result.getFeedback(),
+                    true,
+                    null,
+                    user,
+                    type
+            );
+
+            summaryRepository.save(summary);
+            log.info("✅ [{}] {} 요약/피드백 저장 완료", user.getSlackUsername(), type);
+        }
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,4 +33,4 @@ slack:
 openai:
   api-key: ${OPENAI_API_KEY}
   url: https://api.openai.com/v1/chat/completions
-  model: gpt-3.5-turbo
+  model: gpt-4o-mini

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,5 +31,5 @@ slack:
 openai:
   api-key: ${OPENAI_API_KEY}
   url: https://api.openai.com/v1/chat/completions
-  model: gpt-3.5-turbo
+  model: gpt-4o-mini
 


### PR DESCRIPTION

## 문제상황 :
- 기존의 일부 클래스들이 많은 책임을 가지거나, 중복된 부분이 있어서 테스트 코드를 쓰기 전에 정리할 필요가 있음을 느꼈다.

## 수정 사항 :
- DailySummaryScheduler 의 기능을 오직 스케줄러에만 관련되게 줄였다. 분산한 기능은 SummaryGenerationService가 담당한다.
 -StudyLogQueryService의 중복된 코드를 깔끔히 정리했다.

## 추가한 기능 :
DailySummaryScheduler뿐만 아니라 MonthlySummaryScheduler, WeeklySummaryScheduler 이런 다른 단위의 스케줄러를 추가하였다.

### 스케줄러의 특징 :
일, 주, 월단위의 스케줄러가 실행되는 시간이 다르다. 이는 성능을 고려해 의도한 것이다.

*** 이전 브랜치의 커밋이랑 섞인 것 같아서, 좀 위화감이 드실 수 있습니다. 그리고 히브님이 써주신 이전 pr에 대한 코멘트들도 고려하고 곧 반영하겠습니다~