### PR TITLE
OpenAIClient 클래스의 리팩토링, 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jia/study_tracker/config/WebClientConfig.java
+++ b/src/main/java/com/jia/study_tracker/config/WebClientConfig.java
@@ -1,7 +1,10 @@
 package com.jia.study_tracker.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -9,8 +12,16 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 @Configuration
 public class WebClientConfig {
+
+    @Value("${openai.api-key}")
+    private String openaiApiKey;
+
     @Bean
-    public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
+    public WebClient openAIWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + openaiApiKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
     }
 }

--- a/src/main/java/com/jia/study_tracker/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/jia/study_tracker/controller/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.jia.study_tracker.controller;
+
+import com.jia.study_tracker.exception.InvalidOpenAIResponseException;
+import com.jia.study_tracker.exception.OpenAIClientException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidOpenAIResponseException.class)
+    public ResponseEntity<String> handleInvalidResponse(InvalidOpenAIResponseException e) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body("OpenAI 응답이 유효하지 않습니다: " + e.getMessage());
+    }
+
+
+    @ExceptionHandler(OpenAIClientException.class)
+    public ResponseEntity<String> handleOpenAIError(OpenAIClientException e) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body("AI 요약 생성 중 일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGeneral(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("예기치 못한 오류가 발생했습니다. 문제가 지속되면 관리자에게 문의해주세요.");
+    }
+}

--- a/src/main/java/com/jia/study_tracker/exception/InvalidOpenAIResponseException.java
+++ b/src/main/java/com/jia/study_tracker/exception/InvalidOpenAIResponseException.java
@@ -1,0 +1,10 @@
+package com.jia.study_tracker.exception;
+
+/**
+ * OpenAI API 호출이 됐으나 응답이 비어 있거나, 예상한 형식(요약:, 피드백:)이 아닐 때 발생하는 예외
+ */
+public class InvalidOpenAIResponseException extends RuntimeException {
+  public InvalidOpenAIResponseException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/jia/study_tracker/exception/OpenAIClientException.java
+++ b/src/main/java/com/jia/study_tracker/exception/OpenAIClientException.java
@@ -1,0 +1,11 @@
+package com.jia.study_tracker.exception;
+
+/**
+ * 네트워크 오류, 인증 실패 등 OpenAI API 호출 자체가 실패했을 때 발생하는 예외
+ */
+public class OpenAIClientException extends RuntimeException {
+    public OpenAIClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
+++ b/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
@@ -8,8 +8,6 @@ import com.jia.study_tracker.service.dto.openai.OpenAIResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -33,16 +31,10 @@ import java.util.stream.Collectors;
 @Slf4j
 public class OpenAIClient {
 
-    @Value("${openai.api-key}")
-    private String apiKey;
-
     @Value("${openai.model:gpt-4o-mini}")
     private String model;
 
-    // WebClient는 외부 HTTP 요청을 위한 스프링 비동기 클라이언트
-    private final WebClient.Builder webClientBuilder;
-
-    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+    private final WebClient openAIWebClient;
 
     /**
      * 메소드 : 학습 로그 리스트를 받아 OpenAI에 요청하고 요약 및 피드백을 생성
@@ -81,11 +73,9 @@ public class OpenAIClient {
 
         try {
             // DTO 기반 응답 처리
-            OpenAIResponse response = webClientBuilder.build()
+            OpenAIResponse response = openAIWebClient
                     .post()
-                    .uri(API_URL)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .uri("/chat/completions")
                     .bodyValue(request)
                     .retrieve()
                     .bodyToMono(OpenAIResponse.class)

--- a/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
+++ b/src/main/java/com/jia/study_tracker/service/OpenAIClient.java
@@ -94,6 +94,9 @@ public class OpenAIClient {
 
             return new SummaryResult(summary, feedback);
 
+        } catch (InvalidOpenAIResponseException e) {
+            log.warn("OpenAI 응답 파싱 실패", e);
+            throw e; // 다시 던져서 SummaryGenerationService에서 처리 가능하게
         } catch (WebClientException e) {
             log.error("WebClient 오류로 OpenAI API 호출 실패", e);
             throw new OpenAIClientException("WebClient 오류로 OpenAI API 호출 실패", e);

--- a/src/test/java/com/jia/study_tracker/service/OpenAIClientTest.java
+++ b/src/test/java/com/jia/study_tracker/service/OpenAIClientTest.java
@@ -1,0 +1,118 @@
+package com.jia.study_tracker.service;
+
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.exception.InvalidOpenAIResponseException;
+import com.jia.study_tracker.service.dto.SummaryResult;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * OpenAIClient 테스트
+ *
+ * 목표:
+ * - OpenAIClient의 generateSummaryAndFeedback 메서드가
+ *   정상 응답을 잘 파싱하는지,
+ *   잘못된 응답은 예외로 처리하는지 검증한다.
+ *
+ * 테스트 시나리오:
+ * 1. 정상적인 OpenAI 응답을 받으면 summary와 feedback을 올바르게 파싱한다.
+ * 2. 응답에 '피드백:'이 빠져 있으면 InvalidOpenAIResponseException을 던진다.
+ */
+class OpenAIClientTest {
+
+    private MockWebServer mockWebServer;
+    private OpenAIClient openAIClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        openAIClient = new OpenAIClient(webClient);
+
+        ReflectionTestUtils.setField(openAIClient, "model", "gpt-4o-mini");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @DisplayName("정상 응답이면 요약과 피드백을 잘 파싱한다")
+    @Test
+    void generateSummaryAndFeedback_success() {
+        // given
+        String fakeJsonResponse = """
+            {
+              "choices": [
+                {
+                  "message": {
+                    "content": "요약: 자바 테스트 코드를 학습했습니다.\\n피드백: 꾸준히 연습하고 있어 정말 멋져요!"
+                  }
+                }
+              ]
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(fakeJsonResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        StudyLog log = new StudyLog("자바 테스트 코드 공부", LocalDateTime.now(), new User("U123", "Jia"));
+
+        // when
+        SummaryResult result = openAIClient.generateSummaryAndFeedback(List.of(log));
+
+        // then
+        assertThat(result.getSummary()).isEqualTo("자바 테스트 코드를 학습했습니다.");
+        assertThat(result.getFeedback()).isEqualTo("꾸준히 연습하고 있어 정말 멋져요!");
+    }
+
+    @DisplayName("잘못된 피드백 형식에 InvalidOpenAIResponseException을 던진다")
+    @Test
+    void generateSummaryAndFeedback_invalidFormat_shouldThrowException() {
+        // given: 피드백 항목이 빠진 응답
+        String invalidResponse = """
+            {
+              "choices": [
+                {
+                  "message": {
+                    "content": "요약: 응답 형식이 잘못되었습니다."
+                  }
+                }
+              ]
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(invalidResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        StudyLog log = new StudyLog("오류 발생 가능성 테스트", LocalDateTime.now(), new User("U123", "Jia"));
+
+        // when & then
+        assertThrows(InvalidOpenAIResponseException.class, () ->
+                        openAIClient.generateSummaryAndFeedback(List.of(log)),
+                "응답에 '피드백:'이 빠졌기 때문에 예외가 발생해야 한다");
+
+    }
+}


### PR DESCRIPTION
# 구조 리팩토링

## 수정 사항
- 효율성을 위해 웹클라이언트 빈 등록시 api 키도 함께 등록하도록 수정했습니다.

## 기존 코드
- 기존에서 여러 사용자가 api를 각각 호출할 때마다 키를 넣어서 요청했습니다.

## 수정 후 장점
- API 호출 시 헤더를 설정할 필요가 없게 했습니다.
- api 키가 한 곳에 집중되어 보안상 낫습니다.
- 기존 코드와 달리 build()를 자주 호출하지 않아 내부적으로 매번 새 인스턴스를 만들지 않습니다.