### PR TITLE
[#29] Redis를 이용해 큐로 재시도 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/jia/study_tracker/config/RedisConfig.java
+++ b/src/main/java/com/jia/study_tracker/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.jia.study_tracker.config;
+
+import com.jia.study_tracker.dto.SummaryRetryRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.*;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, SummaryRetryRequest> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, SummaryRetryRequest> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/jia/study_tracker/dto/SummaryRetryRequest.java
+++ b/src/main/java/com/jia/study_tracker/dto/SummaryRetryRequest.java
@@ -1,0 +1,17 @@
+package com.jia.study_tracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SummaryRetryRequest implements Serializable {
+    private String slackUserId;
+    private String slackUsername;
+    private String summaryType;
+    private String targetDate;
+}

--- a/src/main/java/com/jia/study_tracker/dto/SummaryRetryRequest.java
+++ b/src/main/java/com/jia/study_tracker/dto/SummaryRetryRequest.java
@@ -6,6 +6,9 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
+/**
+ * 실패한 요약 요청을 Redis 큐에 저장하기 위한 DTO
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,4 +17,5 @@ public class SummaryRetryRequest implements Serializable {
     private String slackUsername;
     private String summaryType;
     private String targetDate;
+    private int retryCount; // 재시도 제한에 활용
 }

--- a/src/main/java/com/jia/study_tracker/scheduler/SummaryRetryProcessor.java
+++ b/src/main/java/com/jia/study_tracker/scheduler/SummaryRetryProcessor.java
@@ -1,0 +1,92 @@
+package com.jia.study_tracker.scheduler;
+
+import com.jia.study_tracker.domain.StudyLog;
+import com.jia.study_tracker.domain.Summary;
+import com.jia.study_tracker.domain.SummaryType;
+import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.dto.SummaryRetryRequest;
+import com.jia.study_tracker.repository.UserRepository;
+import com.jia.study_tracker.service.OpenAIClient;
+import com.jia.study_tracker.service.SlackNotificationService;
+import com.jia.study_tracker.service.StudyLogQueryService;
+import com.jia.study_tracker.service.SummarySaver;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Redis 큐에 등록된 실패한 요약 요청을 주기적으로 꺼내어 재시도 처리하는 컴포넌트
+ *
+ * 주요 책임:
+ * - Redis 리스트(summary-retry-queue)에서 실패 요청을 하나씩 꺼냄
+ * - 해당 유저의 StudyLog를 조회하고, OpenAI를 통해 요약을 재생성
+ * - 성공 시 Summary 저장 및 사용자에게 Slack으로 요약 전송
+ * - 실패 시 다시 큐에 넣어 재시도 기회를 유지
+ *
+ * 신뢰성 보장:
+ * - SummaryGenerationService에서 실패한 요청을 보존하고,
+ *   일정 간격으로 재시도함으로써 최소 1회 이상 요약 생성 보장 (at-least-once)
+ *
+ * 운영 고려사항:
+ * - 큐의 요청의 쌓임 무한 루프 방지를 위한 retry count 도입 가능
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SummaryRetryProcessor {
+
+    private final RedisTemplate<String, SummaryRetryRequest> redisTemplate;
+    private final UserRepository userRepository;
+    private final StudyLogQueryService studyLogQueryService;
+    private final OpenAIClient openAIClient;
+    private final SlackNotificationService slackNotificationService;
+    private final SummarySaver summarySaver;
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000) // 5분마다 실행
+    public void processRetryQueue() {
+        while (true) {
+            SummaryRetryRequest request = redisTemplate.opsForList().leftPop("summary-retry-queue");
+            if (request == null) break;
+
+            log.info("Redis 재시도 처리 시작: {}", request.getSlackUserId());
+
+            try {
+                User user = userRepository.findById(request.getSlackUserId())
+                        .orElseThrow(() -> new IllegalArgumentException("User not found: " + request.getSlackUserId()));
+
+                LocalDate date = LocalDate.parse(request.getTargetDate());
+                SummaryType type = SummaryType.valueOf(request.getSummaryType());
+
+                List<StudyLog> logs = studyLogQueryService.getLogs(user.getSlackUserId(), date, type);
+                if (logs.isEmpty()) {
+                    log.debug("[{}] {} 로그 없음 - 요약 생략 (재시도)", user.getSlackUsername(), type);
+                    continue;
+                }
+
+                var result = openAIClient.generateSummaryAndFeedback(logs);
+                Summary summary = new Summary(
+                        date,
+                        result.getSummary(),
+                        result.getFeedback(),
+                        true,
+                        null,
+                        user,
+                        type
+                );
+                summarySaver.save(summary);
+                slackNotificationService.sendSummaryToUser(user, summary);
+                log.info("✅ 재시도 성공: {}", user.getSlackUserId());
+
+            } catch (Exception e) {
+                log.error("❌ 재시도 실패 → 다시 큐에 넣음: {} - {}", request.getSlackUserId(), e.getMessage());
+                redisTemplate.opsForList().rightPush("summary-retry-queue", request);
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/jia/study_tracker/service/SlackNotificationService.java
+++ b/src/main/java/com/jia/study_tracker/service/SlackNotificationService.java
@@ -56,7 +56,8 @@ public class SlackNotificationService {
         String errorMessage = String.format("""
                 [%s 요약 ⚠️]
                 %s님의 %s 요약 생성 중 오류가 발생했습니다.
-                반복해서 이 메시지를 받으신다면 관리자에게 문의해주세요.
+                재시도 중이니 잠시만 기다려 주세요.
+                반복적으로 실패하면 관리자에게 문의해주세요.
                 """, type, user.getSlackUsername(), date
         );
 

--- a/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
+++ b/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
@@ -10,6 +10,8 @@ import com.jia.study_tracker.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import com.jia.study_tracker.dto.SummaryRetryRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,6 +25,14 @@ import java.util.List;
  * - OpenAI API 호출을 통해 요약 및 피드백 생성
  * - 결과를 Summary 엔티티로 저장
  * - 사용자에게 슬랙으로 AI 메시지 전송
+ *
+ * 예외 상황 처리:
+ * - OpenAI 응답 이상 또는 호출 실패 시, 슬랙으로 사용자에게 오류 메시지를 알림
+ * - 실패한 요청은 Redis 큐에 등록되어 재시도 프로세서에서 후속 처리됨
+ *
+ * 신뢰성 보장:
+ * - 최소 1회 이상 요약을 시도(at-least-once)하는 구조를 통해
+ *   사용자 로그가 누락되지 않도록 설계됨
  */
 @Service
 @RequiredArgsConstructor
@@ -34,6 +44,7 @@ public class SummaryGenerationService {
     private final OpenAIClient openAIClient;
     private final SlackNotificationService slackNotificationService;
     private final SummarySaver summarySaver;
+    private final RedisTemplate<String, SummaryRetryRequest> redisTemplate;
 
     /**
      * 스케줄러에서 호출됨
@@ -68,17 +79,29 @@ public class SummaryGenerationService {
             );
         } catch (InvalidOpenAIResponseException e) {
             log.warn("⚠️ [{}] {} 요약 생성 실패 - OpenAI 응답 이상: {}", user.getSlackUsername(), type, e.getMessage());
+
             slackNotificationService.sendErrorNotice(user, date, type);
+            registerRetry(user, date, type);
             return;
         } catch (OpenAIClientException e) {
             log.error("❌ [{}] {} API 호출 실패 - {}", user.getSlackUsername(), type, e.getMessage());
-            // 관리자 채널 알림 로직 추가 고려 가능
-            // 재시도 큐에 등록 (예: Redis, DB 테이블, Kafka 등) 고려 가능 - 오버엔지니어링 논란있음
+
+            registerRetry(user, date, type);
             return;
         }
 
         summarySaver.save(summary);
         slackNotificationService.sendSummaryToUser(user, summary);
+    }
+
+    private void registerRetry(User user, LocalDate date, SummaryType type) {
+        SummaryRetryRequest retryRequest = new SummaryRetryRequest(
+                user.getSlackUserId(),
+                user.getSlackUsername(),
+                type.name(),
+                date.toString()
+        );
+        redisTemplate.opsForList().rightPush("summary-retry-queue", retryRequest);
     }
 }
 

--- a/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
+++ b/src/main/java/com/jia/study_tracker/service/SummaryGenerationService.java
@@ -99,7 +99,8 @@ public class SummaryGenerationService {
                 user.getSlackUserId(),
                 user.getSlackUsername(),
                 type.name(),
-                date.toString()
+                date.toString(),
+                0
         );
         redisTemplate.opsForList().rightPush("summary-retry-queue", retryRequest);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,10 @@ spring:
         format_sql: true
         default_batch_fetch_size: 1000
 
+  redis:
+    host: localhost
+    port: 6379
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,10 @@ spring:
         format_sql: false
         default_batch_fetch_size: 1000
 
+  redis:
+    host: localhost
+    port: 6379
+
 logging:
   level:
     org.hibernate.SQL: info

--- a/src/test/java/com/jia/study_tracker/service/SummaryGenerationServiceTest.java
+++ b/src/test/java/com/jia/study_tracker/service/SummaryGenerationServiceTest.java
@@ -4,6 +4,9 @@ import com.jia.study_tracker.domain.StudyLog;
 import com.jia.study_tracker.domain.Summary;
 import com.jia.study_tracker.domain.SummaryType;
 import com.jia.study_tracker.domain.User;
+import com.jia.study_tracker.dto.SummaryRetryRequest;
+import com.jia.study_tracker.exception.InvalidOpenAIResponseException;
+import com.jia.study_tracker.exception.OpenAIClientException;
 import com.jia.study_tracker.repository.UserRepository;
 import com.jia.study_tracker.service.dto.SummaryResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,7 +34,11 @@ import static org.mockito.Mockito.*;
  *
  * 테스트 시나리오:
  * 1. 학습 로그가 없는 사용자는 GPT 요약 생성을 스킵하고 저장하지 않는다.
- * 2. 학습 로그가 있는 사용자는 GPT 요약을 생성하고 저장하고 사용자에게 알림을 보낸다.
+ * 2. 학습 로그가 있는 사용자는 GPT 요약을 생성하고 저장하고 사용자에게 전송한다.
+ * 3. OpenAI 응답이 유효하지 않은 경우 (InvalidOpenAIResponseException 발생),
+ *  시스템은 슬랙으로 오류 메시지를 전송하고, 실패한 요청을 Redis 큐에 등록한다.
+ * 4. OpenAI 호출이 실패하는 경우 (OpenAIClientException 발생),
+ *  실패한 요청을 Redis 큐에 등록한다.
  */
 @ExtendWith(MockitoExtension.class)
 class SummaryGenerationServiceTest {
@@ -48,6 +57,12 @@ class SummaryGenerationServiceTest {
 
     @Mock
     private SummarySaver summarySaver;
+
+    @Mock
+    private RedisTemplate<String, SummaryRetryRequest> redisTemplate;
+
+    @Mock
+    private ListOperations<String, SummaryRetryRequest> listOperations;
 
     @InjectMocks
     private SummaryGenerationService summaryGenerationService;
@@ -97,4 +112,57 @@ class SummaryGenerationServiceTest {
         verify(summarySaver).save(any(Summary.class));
         verify(slackNotificationService).sendSummaryToUser(eq(user), any(Summary.class));
     }
+
+    @Test
+    @DisplayName("InvalidOpenAIResponseException 발생 시 슬랙에 오류 메시지를 보내고 큐에 요청을 등록한다")
+    void shouldNotifyErrorAndQueueWhenInvalidOpenAIResponse() {
+        // given
+        List<StudyLog> logs = List.of(new StudyLog("공부 내용", LocalDateTime.now(), user));
+        SummaryRetryRequest expectedRequest = new SummaryRetryRequest(
+                user.getSlackUserId(),
+                user.getSlackUsername(),
+                type.name(),
+                date.toString()
+        );
+
+        given(userRepository.findAll()).willReturn(List.of(user));
+        given(studyLogQueryService.getLogs(user.getSlackUserId(), date, type)).willReturn(logs);
+        given(openAIClient.generateSummaryAndFeedback(logs))
+                .willThrow(new InvalidOpenAIResponseException("응답 이상"));
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+
+        // when
+        summaryGenerationService.generateSummaries(date, type);
+
+        // then
+        verify(slackNotificationService).sendErrorNotice(eq(user), eq(date), eq(type));
+        verify(listOperations).rightPush(eq("summary-retry-queue"), refEq(expectedRequest));
+    }
+
+
+    @Test
+    @DisplayName("OpenAIClientException 발생 시 큐에 요청을 등록한다")
+    void shouldEnqueueRequestOnOpenAIClientFailure() {
+        // given
+        List<StudyLog> logs = List.of(new StudyLog("공부 내용", LocalDateTime.now(), user));
+        SummaryRetryRequest expectedRequest = new SummaryRetryRequest(
+                user.getSlackUserId(),
+                user.getSlackUsername(),
+                type.name(),
+                date.toString()
+        );
+
+        given(userRepository.findAll()).willReturn(List.of(user));
+        given(studyLogQueryService.getLogs(user.getSlackUserId(), date, type)).willReturn(logs);
+        given(openAIClient.generateSummaryAndFeedback(logs))
+                .willThrow(new OpenAIClientException("서버 오류", new RuntimeException("internal")));
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+
+        // when
+        summaryGenerationService.generateSummaries(date, type);
+
+        // then
+        verify(listOperations).rightPush(eq("summary-retry-queue"), refEq(expectedRequest));
+    }
+
 }

--- a/src/test/java/com/jia/study_tracker/service/SummaryGenerationServiceTest.java
+++ b/src/test/java/com/jia/study_tracker/service/SummaryGenerationServiceTest.java
@@ -122,7 +122,8 @@ class SummaryGenerationServiceTest {
                 user.getSlackUserId(),
                 user.getSlackUsername(),
                 type.name(),
-                date.toString()
+                date.toString(),
+                0
         );
 
         given(userRepository.findAll()).willReturn(List.of(user));
@@ -149,7 +150,8 @@ class SummaryGenerationServiceTest {
                 user.getSlackUserId(),
                 user.getSlackUsername(),
                 type.name(),
-                date.toString()
+                date.toString(),
+                0
         );
 
         given(userRepository.findAll()).willReturn(List.of(user));


### PR DESCRIPTION
Closes #29

### 수정사항
SummaryGenerationService 클래스의 로직을 보충했습니다. 실패시 큐에 넣는 재시도 로직을 구현했습니다. 

#### 추후 고려사항(하지만 현재는 할 생각이 없음)
- 큐에 무한하게 등록이 될 수 있어서 retryCount 필드를 추가할 수 있습니다. 그래서 일정 횟수 초과 시 폐기하거나 에러 큐로 이동할 수 있습니다. 
